### PR TITLE
fix: type definitions for multi flags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,12 +6,12 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
-  packages: write
-  pull-requests: write
 
 jobs:
   release-please:
-    uses: voxpelli/ghatemplates/.github/workflows/release-please-4.yml@main
+    uses: voxpelli/ghatemplates/.github/workflows/release-please-oidc.yml@main
     secrets: inherit
+    with:
+      app-id: '1082006'

--- a/lib/peowly-types.d.ts
+++ b/lib/peowly-types.d.ts
@@ -29,12 +29,12 @@ export interface PeowlyOptions<Flags extends AnyFlags> extends ExtendedParseArgs
 
 type TypedFlag<Flag extends AnyFlag> =
     // Meow extension
-    // Flag extends {type: 'number'}
+    // Flag['type'] extends 'number'
     //   ? number
     //   :
-      Flag extends { type: 'string' }
+      Flag['type'] extends 'string'
         ? string
-        : Flag extends { type: 'boolean' }
+        : Flag['type'] extends 'boolean'
           ? boolean
           : unknown;
 


### PR DESCRIPTION
Improve type definitions for flags to ensure correct type inference, particularly for multiple string flags and their defaults. Add tests to validate the expected behavior of these types.