### PR TITLE
fix: display boolean default:true flags as --[no-]flag

### DIFF
--- a/lib/format-lists.js
+++ b/lib/format-lists.js
@@ -4,12 +4,123 @@
  * @property {string} [keyPrefix] A prefix for the name, eg. "--"
  * @property {number} [padName] The minimum padding between names and descriptions
  * @property {string} [shortFlagPrefix] A prefix for the shortFlag, defaults to "-"
+ * @property {number} [maxDefaultDisplayLength] Max length of a default value before truncation with ellipsis, defaults to 20
  */
+
+/**
+ * Default max length of a default value shown in help text before truncation.
+ * Long defaults are truncated with an ellipsis to avoid pushing descriptions
+ * too far right.
+ */
+const DEFAULT_MAX_DISPLAY_LENGTH = 20;
+
+/**
+ * Formats the default value of a flag item into a `[default: value]` annotation
+ * string, or returns `undefined` if no default should be shown.
+ *
+ * - Boolean `default: true` → `'on'` (paired with the `[no-]` prefix)
+ * - Boolean `default: false` → `undefined` (trivial default, not shown)
+ * - String with truthy default → the value (or comma-joined for multiple)
+ * - Number with defined default → the value (or comma-joined for arrays)
+ *
+ * Values longer than `maxDefaultDisplayLength` (default: {@link DEFAULT_MAX_DISPLAY_LENGTH}) are truncated with `…`.
+ *
+ * @param {import('./flag-types.d.ts').AnyFlag} item
+ * @param {number} [maxDisplayLength] Max length before truncation, defaults to {@link DEFAULT_MAX_DISPLAY_LENGTH}
+ * @returns {string | undefined}
+ */
+function formatDefault (item, maxDisplayLength = DEFAULT_MAX_DISPLAY_LENGTH) {
+  const { 'default': value, type } = item;
+
+  /** @type {string | undefined} */
+  let displayValue;
+
+  if (type === 'boolean') {
+    displayValue = value === true ? 'on' : undefined;
+  } else if (type === 'string' && value) {
+    displayValue = Array.isArray(value) ? value.join(', ') : value;
+  } else if (type === 'number' && value !== undefined) {
+    displayValue = Array.isArray(value) ? value.join(', ') : String(value);
+  }
+
+  if (displayValue !== undefined && displayValue.length > maxDisplayLength) {
+    return displayValue.slice(0, maxDisplayLength - 1) + '…';
+  }
+
+  return displayValue;
+}
+
+/**
+ * Computes the display name for a help list item, applying the `[no-]` prefix
+ * for boolean flags with `default: true` (the git convention for negatable flags).
+ *
+ * Default value annotations (`[default: value]`) are handled separately by
+ * `formatDisplayName` so they can be right-aligned in the flag area.
+ *
+ * @param {string} name
+ * @param {string|import('./help-list-types.d.ts').HelpListItem|undefined} item
+ * @returns {string}
+ */
+function getDisplayName (name, item) {
+  if (!item || typeof item === 'string' || !('type' in item)) {
+    return name;
+  }
+
+  // Boolean flags with default: true get the [no-] prefix to show the canonical
+  // flag name and indicate a negation variant exists (git convention).
+  return item.type === 'boolean' && item.default === true
+    ? `[no-]${name}`
+    : name;
+}
+
+/**
+ * Formats an already-computed display name with short flag prefix, key prefix,
+ * padding, and right-aligned `[default: value]` suffix.
+ *
+ * Layout: `-c, --flag   [default: value]`
+ * When the flag name is long enough to reach the default column, the default
+ * follows with a single space separator (padEnd collapses naturally).
+ *
+ * @param {string} displayName
+ * @param {string|import('./help-list-types.d.ts').HelpListItem|undefined} item
+ * @param {Readonly<Pick<HelpListOptions, 'keyPrefix'|'padName'|'shortFlagPrefix'|'maxDefaultDisplayLength'>>} options
+ * @returns {string}
+ */
+function formatDisplayName (displayName, item, options = {}) {
+  const {
+    keyPrefix = '',
+    maxDefaultDisplayLength = DEFAULT_MAX_DISPLAY_LENGTH,
+    padName = 0,
+    shortFlagPrefix = '-',
+  } = options;
+
+  // Short flag as left-aligned prefix: `-c, ` or 4-space pad when keyPrefix is set
+  const hasShort = typeof item === 'object' && 'type' in item && item.short;
+  const shortPrefix = hasShort
+    ? `${shortFlagPrefix}${item.short}, `
+    : (keyPrefix
+        ? '    '
+        : '');
+
+  // Default annotation as right-aligned suffix
+  const defaultStr = typeof item === 'object' && 'type' in item
+    ? formatDefault(item, maxDefaultDisplayLength)
+    : undefined;
+  const defaultAnnotation = defaultStr ? `[default: ${defaultStr}]` : '';
+
+  const name = shortPrefix + keyPrefix + displayName;
+  if (defaultAnnotation) {
+    // Ensure at least 2 spaces between the name and the default annotation
+    const targetWidth = Math.max(padName - defaultAnnotation.length, name.length + 2);
+    return name.padEnd(targetWidth) + defaultAnnotation;
+  }
+  return name.padEnd(padName);
+}
 
 /**
  * @param {string} name
  * @param {string|import('./help-list-types.d.ts').HelpListItem|undefined} item
- * @param {Readonly<Pick<HelpListOptions, 'keyPrefix'|'padName'|'shortFlagPrefix'>>} options
+ * @param {Readonly<Pick<HelpListOptions, 'keyPrefix'|'padName'|'shortFlagPrefix'|'maxDefaultDisplayLength'>>} options
  * @returns {string}
  */
 function formatHelpListName (name, item, options = {}) {
@@ -17,38 +128,12 @@ function formatHelpListName (name, item, options = {}) {
     return '';
   }
 
-  const {
-    keyPrefix = '',
-    padName = 0,
-    shortFlagPrefix = '-',
-  } = options;
-
-  const richItem = typeof item === 'string' ? { description: item } : item;
-
-  let formattedShortFlag = '';
-
-  if ('type' in richItem) {
-    if (richItem.type === 'string' && richItem.default) {
-      name = richItem.multiple
-        ? `${name} [${richItem.default.join(', ')}]`
-        : `${name} [${richItem.default}]`;
-    } else if (richItem.type === 'number' && richItem.default !== undefined) {
-      name = Array.isArray(richItem.default)
-        ? `${name} [${richItem.default.join(', ')}]`
-        : `${name} [${richItem.default}]`;
-    }
-
-    if (richItem.short) {
-      formattedShortFlag = `  ${shortFlagPrefix}${richItem.short}`;
-    }
-  }
-
-  return (keyPrefix + name).padEnd(padName - formattedShortFlag.length) + formattedShortFlag;
+  return formatDisplayName(getDisplayName(name, item), item, options);
 }
 
 /**
  * @param {import('./help-list-types.d.ts').HelpList} list
- * @param {Readonly<Pick<HelpListOptions, 'keyPrefix'>>} options
+ * @param {Readonly<Pick<HelpListOptions, 'keyPrefix'|'padName'|'shortFlagPrefix'|'maxDefaultDisplayLength'>>} options
  * @returns {number}
  */
 export function getHelpListMaxNamePadding (list, options = {}) {
@@ -67,6 +152,10 @@ export function getHelpListMaxNamePadding (list, options = {}) {
 }
 
 /**
+ * Formats a help list into a string. Each line is indented with `indent` spaces.
+ * The result is trimmed of trailing whitespace (e.g. the final newline) but
+ * preserves leading indentation on the first line.
+ *
  * @param {import('./help-list-types.d.ts').HelpList} list
  * @param {number} indent
  * @param {HelpListOptions} options
@@ -78,15 +167,27 @@ export function formatHelpList (list, indent, options = {}) {
     padName = 0,
   } = options;
 
-  const names = Object.keys(list).toSorted();
+  // Pre-compute display names once for sorting, padding, and printing.
+  // Sort by canonical key name (not display name) so that boolean flags with
+  // default: true (displayed as --[no-]flag) sort under their canonical name
+  // (e.g. "color" under 'c') rather than under the [no-] prefix, matching git.
+  const entries = Object.keys(list)
+    .map(name => ({ name, displayName: getDisplayName(name, list[name]) }))
+    .toSorted((a, b) => a.name < b.name ? -1 : (a.name > b.name ? 1 : 0));
 
-  const calculatedPadName = fixedPadName
-    ? padName
-    : Math.max(padName, getHelpListMaxNamePadding(list, options));
+  // Mirrors getHelpListMaxNamePadding but reuses pre-computed display names
+  let maxNameLength = 0;
+  if (!fixedPadName) {
+    for (const { displayName, name } of entries) {
+      const formatted = formatDisplayName(displayName, list[name], options);
+      if (formatted.length > maxNameLength) maxNameLength = formatted.length;
+    }
+  }
+  const calculatedPadName = fixedPadName ? padName : Math.max(padName, maxNameLength);
 
   let result = '';
 
-  for (const name of names) {
+  for (const { displayName, name } of entries) {
     const item = list[name];
 
     const description = typeof item === 'object' ? item.description : item;
@@ -98,11 +199,11 @@ export function formatHelpList (list, indent, options = {}) {
       : '';
 
     result += ''.padEnd(indent) +
-      formatHelpListName(name, item, { ...options, padName: calculatedPadName }) + '  ' +
+      formatDisplayName(displayName, item, { ...options, padName: calculatedPadName }) + '  ' +
       description + aliasAnnotation + '\n';
   }
 
-  return result.trim();
+  return result.trimEnd();
 }
 
 /**
@@ -171,7 +272,7 @@ export function formatGroupedHelpList (list, indent, options = {}) {
     const groupName = groupKey === defaultGroupSymbol ? defaultGroupName : groupKey;
 
     result += '\n' + ''.padEnd(indent) + groupName + '\n';
-    result += ''.padEnd(flagIndent) + formatHelpList(groupList, flagIndent, listOptions) + '\n';
+    result += formatHelpList(groupList, flagIndent, listOptions) + '\n';
   }
 
   return result;

--- a/test/format-help.spec.js
+++ b/test/format-help.spec.js
@@ -155,6 +155,48 @@ describe('format-help', () => {
       assert(result.includes('h'));
       assert(result.includes('Help'));
     });
+
+    it('should display boolean flags with default: true using [no-] convention', () => {
+      const result = formatHelpMessage('test-cli', {
+        flags: {
+          color: {
+            type: 'boolean',
+            'default': true,
+            description: 'Enable color output',
+          },
+          verbose: {
+            type: 'boolean',
+            'default': false,
+            description: 'Enable verbose output',
+          },
+        },
+      });
+      assert(result.includes('--[no-]color'));
+      assert(result.includes('Enable color output'));
+      assert(result.includes('--verbose'));
+      assert(!result.includes('--color '));
+    });
+
+    it('should produce exact end-to-end output with mixed flags', () => {
+      const result = formatHelpMessage('my-cli', {
+        usage: '[options]',
+        flags: {
+          color: { type: 'boolean', 'default': true, description: 'Enable color' },
+          debug: { type: 'boolean', 'default': false, 'short': 'd', description: 'Debug mode' },
+        },
+      });
+      assert.equal(result, [
+        '  Usage',
+        '    $ my-cli [options]',
+        '',
+        '  Options',
+        '        --[no-]color  [default: on]  Enable color',
+        '    -d, --debug                      Debug mode',
+        '        --help                       Prints this help and exits.',
+        '        --version                    Prints current version and exits.',
+        '',
+      ].join('\n'));
+    });
   });
 
   describe('defaultFlags', () => {

--- a/test/format-lists.spec.js
+++ b/test/format-lists.spec.js
@@ -104,9 +104,158 @@ describe('format-lists', () => {
       assert(result.includes('ts'));
     });
 
+    it('should display boolean flags with default: true using [no-] convention', () => {
+      const list = {
+        color: {
+          type: 'boolean',
+          'default': true,
+          description: 'Enable color',
+        },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      assert(result.includes('--[no-]color'));
+      assert(!result.includes('--color '));
+    });
+
+    it('should display boolean flags with default: false without [no-] prefix or [true] default', () => {
+      const list = {
+        verbose: {
+          type: 'boolean',
+          'default': false,
+          description: 'Verbose',
+        },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      assert(result.includes('--verbose'));
+      assert(!result.includes('--no-verbose'));
+      assert(!result.includes('[default: on]'), 'should not show [default: on] for default: false');
+    });
+
+    it('should sort by canonical name so [no-] flags appear under their base name', () => {
+      const list = {
+        color: { type: 'boolean', 'default': true, description: 'Enable color' },
+        debug: { type: 'boolean', 'default': false, description: 'Debug mode' },
+        output: { type: 'string', description: 'Output file' },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      const colorIdx = result.indexOf('--[no-]color');
+      const debugIdx = result.indexOf('--debug');
+      const outputIdx = result.indexOf('--output');
+      assert(colorIdx !== -1, 'should contain --[no-]color');
+      assert(debugIdx !== -1, 'should contain --debug');
+      assert(outputIdx !== -1, 'should contain --output');
+      // Sort by canonical name: color (c) < debug (d) < output (o)
+      assert(colorIdx < debugIdx, '--[no-]color should sort before --debug');
+      assert(debugIdx < outputIdx, '--debug should sort before --output');
+    });
+
+    it('should sort [no-] flag before a flag with the same prefix (e.g. color vs colorful)', () => {
+      const list = {
+        color: { type: 'boolean', 'default': true, description: 'Enable color' },
+        colorful: { type: 'boolean', 'default': false, description: 'Colorful output' },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      const colorIdx = result.indexOf('--[no-]color');
+      const colorfulIdx = result.indexOf('--colorful');
+      assert(colorIdx !== -1, 'should contain --[no-]color');
+      assert(colorfulIdx !== -1, 'should contain --colorful');
+      // color < colorful by canonical name, so [no-]color sorts first
+      assert(colorIdx < colorfulIdx, '--[no-]color should sort before --colorful');
+    });
+
+    it('should produce exact output with mixed types, defaults, short flags, and [no-] convention', () => {
+      const list = {
+        color: { type: 'boolean', 'default': true, 'short': 'c', description: 'Enable color' },
+        debug: { type: 'boolean', 'default': false, description: 'Debug mode' },
+        output: { type: 'string', 'default': 'out.js', description: 'Output file' },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      assert.equal(result, [
+        '  -c, --[no-]color  [default: on]  Enable color',
+        '      --debug                      Debug mode',
+        '      --output  [default: out.js]  Output file',
+      ].join('\n'));
+    });
+
     it('should handle empty list', () => {
       const result = formatHelpList({}, 2);
       assert.equal(typeof result, 'string');
+    });
+
+    it('should let long flag names expand into the default column', () => {
+      const list = {
+        color: { type: 'boolean', 'default': true, description: 'Enable color output' },
+        'very-long-flag-name': { type: 'boolean', 'default': false, description: 'A very long flag' },
+        debug: { type: 'number', 'default': 1, description: 'Debug mode' },
+        help: { type: 'boolean', 'default': false, description: 'Prints this help and exits.' },
+        output: { type: 'string', 'default': 'dist.js', description: 'Output file' },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      assert.equal(result, [
+        '      --[no-]color   [default: on]  Enable color output',
+        '      --debug         [default: 1]  Debug mode',
+        '      --help                        Prints this help and exits.',
+        '      --output  [default: dist.js]  Output file',
+        '      --very-long-flag-name         A very long flag',
+      ].join('\n'));
+    });
+
+    it('should truncate long default values with ellipsis', () => {
+      const list = {
+        config: { type: 'string', 'default': '/very/long/path/to/config/file.js', description: 'Config file' },
+        debug: { type: 'boolean', 'default': false, description: 'Debug mode' },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      assert(result.includes('[default: /very/long/path/to'));
+      assert(result.includes('…'));
+      assert(!result.includes('/very/long/path/to/config/file.js'));
+    });
+
+    it('should truncate long defaults for all types (single and multiple)', () => {
+      const list = {
+        // Long string (single)
+        longStr: { type: 'string', 'default': 'this-is-a-very-long-default-value.js', description: 'Long string' },
+        // Long string (multiple) - joined exceeds 20
+        longMulti: { type: 'string', 'default': ['javascript', 'typescript', 'jsx'], multiple: true, description: 'Long multi string' },
+        // Long number (multiple) - joined exceeds 20
+        longMultiNum: { type: 'number', 'default': [3000, 3001, 3002, 3003, 3004], multiple: true, description: 'Long multi number' },
+        // Short string (multiple) - joined under 20
+        shortMulti: { type: 'string', 'default': ['js', 'ts'], multiple: true, description: 'Short multi' },
+        // Exact 20 chars - should NOT truncate
+        exact20: { type: 'string', 'default': '12345678901234567890', description: 'Exact 20' },
+        // 21 chars - should truncate
+        over20: { type: 'string', 'default': '123456789012345678901', description: '21 chars' },
+      };
+      const result = formatHelpList(list, 2, { keyPrefix: '--' });
+      // Long string (single) - truncated
+      assert(result.includes('this-is-a-very-long…'));
+      // Long string (multiple) - joined then truncated
+      assert(result.includes('javascript, typescr…'));
+      // Long number (multiple) - joined then truncated
+      assert(result.includes('3000, 3001, 3002, 3…'));
+      // Short multiple - NOT truncated
+      assert(result.includes('[default: js, ts]'));
+      // Exact 20 chars - NOT truncated
+      assert(result.includes('[default: 12345678901234567890]'));
+      // 21 chars - truncated
+      assert(result.includes('[default: 1234567890123456789…]'));
+    });
+
+    it('should respect maxDefaultDisplayLength option', () => {
+      const list = {
+        config: { type: 'string', 'default': 'this-is-a-very-long-default-value.js', description: 'Config file' },
+      };
+      // Default (20) truncates
+      const defaultResult = formatHelpList(list, 2, { keyPrefix: '--' });
+      assert(defaultResult.includes('…'));
+      assert(!defaultResult.includes('this-is-a-very-long-default-value.js'));
+      // Custom (40) does not truncate
+      const customResult = formatHelpList(list, 2, { keyPrefix: '--', maxDefaultDisplayLength: 40 });
+      assert(!customResult.includes('…'));
+      assert(customResult.includes('this-is-a-very-long-default-value.js'));
+      // Custom (10) truncates shorter
+      const shortResult = formatHelpList(list, 2, { keyPrefix: '--', maxDefaultDisplayLength: 10 });
+      assert(shortResult.includes('this-is-a…'));
     });
   });
 
@@ -197,6 +346,25 @@ describe('format-lists', () => {
       assert(result.includes('verbose'));
       assert(result.includes('very-long-flag-name'));
     });
+
+    it('should produce exact output with groups and default group', () => {
+      const list = {
+        build: { description: 'Build the project', listGroup: 'Commands' },
+        test: { description: 'Run tests', listGroup: 'Commands' },
+        clean: { description: 'Clean build artifacts' },
+      };
+      const result = formatGroupedHelpList(list, 2, { defaultGroupName: 'Other' });
+      assert.equal(result, [
+        '',
+        '  Commands',
+        '    build  Build the project',
+        '    test   Run tests',
+        '',
+        '  Other',
+        '    clean  Clean build artifacts',
+        '',
+      ].join('\n'));
+    });
   });
 
   describe('formatGroupedFlagList()', () => {
@@ -241,6 +409,27 @@ describe('format-lists', () => {
     it('should handle empty flag list', () => {
       const result = formatGroupedFlagList({}, 2);
       assert.equal(typeof result, 'string');
+    });
+
+    it('should produce exact output with mixed types, groups, [no-] convention, and short flags', () => {
+      const list = {
+        color: { type: 'boolean', 'default': true, 'short': 'c', description: 'Enable color' },
+        debug: { type: 'boolean', 'default': false, description: 'Debug mode' },
+        output: { type: 'string', 'default': 'out.js', description: 'Output file', listGroup: 'Output Options' },
+        verbose: { type: 'boolean', 'default': false, description: 'Verbose', listGroup: 'Output Options' },
+      };
+      const result = formatGroupedFlagList(list, 2);
+      assert.equal(result, [
+        '',
+        '  Output Options',
+        '        --output  [default: out.js]  Output file',
+        '        --verbose                    Verbose',
+        '',
+        '  Options',
+        '    -c, --[no-]color  [default: on]  Enable color',
+        '        --debug                      Debug mode',
+        '',
+      ].join('\n'));
     });
   });
 });

--- a/test/peowly-number-flags.spec.js
+++ b/test/peowly-number-flags.spec.js
@@ -141,7 +141,7 @@ describe('peowly number flags', () => {
         2
       );
 
-      assert.match(help, /\[3\]/);
+      assert.match(help, /\[default: 3\]/);
     });
   });
 });


### PR DESCRIPTION
- Boolean flags with default: true now display as --[no-]color (git convention) instead of --no-color, showing the canonical flag name and indicating the negation variant exists
- All default values use [default: value] notation (Click/yargs convention): string → [default: out.js], number → [default: 3], boolean → [default: on]
- Boolean default: false shows no annotation (trivial default)
- Short flags are now left-aligned prefixes (-c, --flag) instead of right-aligned suffixes (commander.js/yargs convention)
- Default annotations are right-aligned in the flag area with min 2-space gap
- Long flag names expand into the default column (padEnd collapses naturally)
- Sort by canonical key name so [no-]color sorts under 'c', matching git
- Long default values truncated with ellipsis at 20 chars (configurable via maxDefaultDisplayLength option in HelpListOptions)
- Refactored getDisplayName/formatDefault/formatDisplayName for DRY: getDisplayName returns name with [no-] prefix only, formatDefault handles all default value formatting, formatDisplayName handles layout
- formatHelpList pre-computes display names once (was 3x per item)
- trim() → trimEnd() in formatHelpList preserves first-line indent
- formatGroupedHelpList removed redundant .padEnd(flagIndent) prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Format boolean flags with `default: true` as `--[no-]flag`.
- Show non-trivial defaults as `[default: value]`; omit the annotation for boolean `false`.
- Align short flags and default annotations with a minimum two-space gap.
- Sort flags by canonical key name.
- Truncate default values at 20 characters by default. Configure the limit with `maxDefaultDisplayLength`.
- Refactor display-name and default-formatting helpers. Precompute display names in `formatHelpList`.
- Preserve first-line indentation and remove redundant grouped-list padding.
- Update help-output tests for boolean, numeric, sorting, alignment, truncation, and grouped-list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->